### PR TITLE
Fix ResetAction error log

### DIFF
--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -161,7 +161,7 @@ final class ResetAction
             } catch (AccountStatusException $ex) {
                 // We simply do not authenticate users which do not pass the user
                 // checker (not enabled, expired, etc.).
-                $this->getLogger()->warning(sprintf(
+                $this->logger->warning(sprintf(
                     'Unable to login user %d after password reset',
                     $user->getId()
                 ), ['exception' => $ex]);


### PR DESCRIPTION
## Fix logger in ResetAction 

In ResetAction class there is a call of inexistent method "getLogger". The issue will reproduce if you reset a password for disabled user.

I am targeting this branch, because this is a small bug fix.

```markdown
### Fixed
 - Fixed invocation of inexistent "getLogger" method. Changed to access property.
```
